### PR TITLE
Bump to manylinux_2_28

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           for f in patches/*; do patch -p0 < ${f}; done
           docker run --rm -v $PWD/zeroc-ice-3.6.5:/build builder /bin/bash -c "cd /build ; /opt/python/${{ matrix.version }}/bin/python setup.py build -j 3"
           docker run --rm -v $PWD/zeroc-ice-3.6.5:/build builder /bin/bash -c "cd /build ; /opt/python/${{ matrix.version }}/bin/python setup.py bdist_wheel"
-          docker run --rm -v $PWD/zeroc-ice-3.6.5:/build builder auditwheel repair --plat 'manylinux2014_x86_64' -w /build/dist /build/dist/zeroc_ice-3.6.5-${{ matrix.version }}-linux_x86_64.whl
+          docker run --rm -v $PWD/zeroc-ice-3.6.5:/build builder auditwheel repair --plat 'manylinux_2_28_x86_64' -w /build/dist /build/dist/zeroc_ice-3.6.5-${{ matrix.version }}-linux_x86_64.whl
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for lowest common denominator Linux native artifact build
 # --------------------------------------------------------------------
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM quay.io/pypa/manylinux_2_28_x86_64
 
 RUN yum install -y -q bzip2-devel openssl-devel

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Builds ZeroC Ice Python manylinux_2_28 wheel packages for Linux x86_64.
 ** NOTE ** : the manylinux_2_28 wheel packages are bundled with
 OpenSSL 1.1.1k - see
 https://github.com/pypa/manylinux#manylinux_2_28-almalinux-8-based.
+
+`pip>=20.3` is required to use these artifacts.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Linux x86_64 Zeroc Ice Python Builder
 =====================================
 
-Builds ZeroC Ice Python manylinux2014 wheel packages for Linux x86_64.
+Builds ZeroC Ice Python manylinux_2_28 wheel packages for Linux x86_64.
 
-** WARNING ** : the manylinux2014 wheel packages are bundled with
-OpenSSL 1.0.2k and should not be used in production - see
-https://github.com/pypa/manylinux#manylinux2014-centos-7-based.
+** NOTE ** : the manylinux_2_28 wheel packages are bundled with
+OpenSSL 1.1.1k - see
+https://github.com/pypa/manylinux#manylinux_2_28-almalinux-8-based.


### PR DESCRIPTION
Switch from manylinux2014 (CentOS 7) to manylinux_2_28 (AlmaLinux 8).

See:

 * https://github.com/pypa/manylinux#docker-images