### PR TITLE
Python 3.12 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,12 @@ jobs:
   build:
     strategy:
       matrix:
-        version: ['cp38-cp38', 'cp39-cp39', 'cp310-cp310', 'cp311-cp311']
+        version:
+          - 'cp38-cp38'
+          - 'cp39-cp39'
+          - 'cp310-cp310'
+          - 'cp311-cp311'
+          - 'cp312-cp312'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules


### PR DESCRIPTION
This is the minimal set of changes required to get a pre-built Ice 3.6.5 wheel packages for Python 3.12.

The primary additional patch is related to the removal of the `imp` library - see https://docs.python.org/3/whatsnew/3.12.html. A new patch is added similar to https://github.com/zeroc-ice/ice/commit/078cf0b81d4ebdf8014bad269eaefdc2f583c4f3.

The pre-built wheel package has been lightly tested under Ubuntu 23.10 where `python3.12` can be installed and the Ice module can be imported minimally

```
root@eba7bd817e79:/# python3.12 -mvenv venv
root@eba7bd817e79:/# venv/bin/pip install /tmp/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl 
Processing /tmp/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl
Installing collected packages: zeroc-ice
Successfully installed zeroc-ice-3.6.5
root@eba7bd817e79:/# venv/bin/python
Python 3.12.0 (main, Oct  4 2023, 06:27:34) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import Ice
>>> 
```