### PR TITLE
Generate pre-built Ice Python wheel packages for Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Build
@@ -33,9 +33,9 @@ jobs:
           docker run --rm -v $PWD/zeroc-ice-3.6.5:/build builder /bin/bash -c "cd /build ; /opt/python/${{ matrix.version }}/bin/python setup.py bdist_wheel"
           docker run --rm -v $PWD/zeroc-ice-3.6.5:/build builder auditwheel repair --plat 'manylinux_2_28_x86_64' -w /build/dist /build/dist/zeroc_ice-3.6.5-${{ matrix.version }}-linux_x86_64.whl
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.version }}
           path: zeroc-ice-3.6.5/dist/*manylinux*.whl
           if-no-files-found: error
   release:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts from build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
       - name: List artifacts
         run: ls -R
       - name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           for f in patches/*; do patch -p0 < ${f}; done
           docker run --rm -v $PWD/zeroc-ice-3.6.5:/build builder /bin/bash -c "cd /build ; /opt/python/${{ matrix.version }}/bin/python setup.py build -j 3"
           docker run --rm -v $PWD/zeroc-ice-3.6.5:/build builder /bin/bash -c "cd /build ; /opt/python/${{ matrix.version }}/bin/python setup.py bdist_wheel"
-          docker run --rm -v $PWD/zeroc-ice-3.6.5:/build builder auditwheel repair --plat 'manylinux_2_28_x86_64' -w /build/dist /build/dist/zeroc_ice-3.6.5-${{ matrix.version }}-linux_x86_64.whl
+          docker run --rm -v $PWD/zeroc-ice-3.6.5:/build builder auditwheel repair --only-plat --plat 'manylinux_2_28_x86_64' -w /build/dist /build/dist/zeroc_ice-3.6.5-${{ matrix.version }}-linux_x86_64.whl
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,8 @@ jobs:
         uses: actions/download-artifact@v8
       - name: List artifacts
         run: ls -R
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            artifacts/*.whl
+      - name: Create a GitHub release
+        if: startsWith(github.ref, 'refs/tags')
+        run: gh release create --generate-notes "${GITHUB_REF#refs/tags/}" artifacts*/*.whl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       matrix:
         version:
-          - 'cp38-cp38'
-          - 'cp39-cp39'
           - 'cp310-cp310'
           - 'cp311-cp311'
           - 'cp312-cp312'
+          - 'cp313-cp313'
+          - 'cp314-cp314'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "patches"]
 	path = patches
-	url = https://github.com/glencoesoftware/zeroc-ice-py-patches.git
+	url = https://github.com/glencoesoftware/zeroc-ice-py-patches

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,8 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
 RUN yum install -y -q bzip2-devel openssl-devel
+RUN /opt/python/cp310-cp310/bin/python -m pip install --upgrade pip setuptools wheel
+RUN /opt/python/cp311-cp311/bin/python -m pip install --upgrade pip setuptools wheel
+RUN /opt/python/cp312-cp312/bin/python -m pip install --upgrade pip setuptools wheel
+RUN /opt/python/cp313-cp313/bin/python -m pip install --upgrade pip setuptools wheel
+RUN /opt/python/cp314-cp314/bin/python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
Fixes #4 

# Summary of changes

- consumes the latest patches pushed to https://github.com/glencoesoftware/zeroc-ice-py-patches 
- update the wheel package build to install additional prerequisites and only produce a wheel package for the lowest priority manylinux tag
- updates the GitHub actions infrastructure to run on Node.js 24 - see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- update the GitHub workflow matrix to build wheel packages between Python 3.10 up to and including Python 3.14.

# Functional testing

For each supported Python version in a Linux / x86_64 environment, replacing `xx` as appropriate,
- create a new virtual environment (`python3.xx -mvenv venv.py3xx`)
- install Ice python using the wheel packages produced as an artifact of this PR (`venv.py3xx/bin/pip install zeroc_ice-3.6.5-cp3xx-cp3xx-manylinux_2_28_x86_64.whl`)
- install OMERO.py (`venv.py3xx/bin/pip install omero-py`)
- test a few workflows against a test/dev OMERO serv
  1. authenticate `venv.py3xx/bin/omero login`
  2. import an image `touch test.fake && venv.py3xx/bin/omero import test.fake`
  3. update an object `venv.py3xx/bin/omero obj update Image:xx description='test'`
  4. make a query `venv.py3xx/bin/omero hql 'select i from Image i' --all`
  5. logout `venv.py3xx/bin/omero logout`
  